### PR TITLE
Prevent release names from ending in -

### DIFF
--- a/set-up-demo/main.py
+++ b/set-up-demo/main.py
@@ -94,6 +94,9 @@ def set_up_demo(event, context):
     release_name = (
         "-".join([user, branch]).replace("_", "-").replace("/", "-").lower()[:25]
     )  # Get at most 35 characters for the limitation of deployment name
+    
+    if release_name.endswith("-"):
+        release_name = release_name[0:-1]
 
     # Upload the github code as a tarball to the bucket in Google Cloud Storage.
     upload_tarball_to_storage(user, repo, branch, bucket_name, destination_blob_name)

--- a/set-up-demo/main.py
+++ b/set-up-demo/main.py
@@ -96,7 +96,7 @@ def set_up_demo(event, context):
     )  # Get at most 35 characters for the limitation of deployment name
     
     if release_name.endswith("-"):
-        release_name = release_name[0:-1]
+        release_name = release_name.strip("-")
 
     # Upload the github code as a tarball to the bucket in Google Cloud Storage.
     upload_tarball_to_storage(user, repo, branch, bucket_name, destination_blob_name)


### PR DESCRIPTION
Helm does not like release names ending in `-`. Prevent that by detecting if we end in `-`, and subract one character further.